### PR TITLE
docs: add README and replace hardcoded email with env fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,49 @@
+# Craft Poetry
+
+## 🚀 What is this?
+Craft Poetry is a Next.js web app for writing and validating poetic forms, currently focused on haiku with live structural checks and optional AI feedback.
+
+## 🎯 Problem it solves
+Writing poetry in strict formats is hard to validate manually. This project helps authors quickly check form-specific rules (like line count and syllables), catch common issues, and save drafts in one place.
+
+## ✨ Key Features
+- Real-time poem validation while typing, including line count, syllable structure, language-character checks, and line word-count limits for haiku.
+- Separate technical and semantic feedback, including warnings (for example rhyme and cliché warnings).
+- Optional AI-assisted analysis endpoint for suggestions, localized by selected language.
+- Form selection flow for multiple poetry types (Haiku and Sonnet), with a validator registry for extensibility.
+- Draft persistence and browsing using Prisma + PostgreSQL (`/drafts`, `/form/[id]`, `/library`).
+- Built-in localization support for English, Ukrainian, and Russian.
+
+## 🛠 Tech Stack
+- Next.js (Pages Router) + React + TypeScript
+- Material UI (MUI) + Emotion
+- Prisma ORM + PostgreSQL
+- next-i18next / i18next
+- OpenAI Node SDK
+
+## ⚡ Quick Start
+```bash
+npm install
+npm run dev
+```
+
+Open: `http://localhost:3000`
+
+## 📦 Scripts
+- `npm run dev` — start development server
+- `npm run build` — production build
+- `npm run start` — run built app
+- `npm run lint` — run ESLint + type checks
+- `npm run lint:types` — TypeScript checks only
+- `npm run format` — format code with Prettier
+- `npm run open_db` — open Prisma Studio
+- `npm run push_db` — push Prisma schema to database
+
+## 📌 Notes
+- Required environment variables:
+  - `OPENAI_API_KEY`
+  - `POSTGRES_PRISMA_URL`
+  - `POSTGRES_URL_NON_POOLING`
+  - `DEFAULT_AUTHOR_EMAIL` (must match an existing `User.email` in the database for form creation)
+- Sonnet validation is currently a placeholder and returns no rule violations.
+- API routes are implemented in `pages/api/*`; authentication scaffolding exists but is currently commented out.

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -1,4 +1,5 @@
-export const MOCK_EMAIL = "oleh.prymachenko@gmail.com";
+export const MOCK_EMAIL =
+  process.env.DEFAULT_AUTHOR_EMAIL ?? "demo@example.com";
 
 export enum PoetryForm {
   Sonnet = "Sonnet",


### PR DESCRIPTION
### Motivation
- Provide a clear, public-facing `README.md` so contributors and users can quickly understand the project, how to run it, and required environment variables.
- Remove a hardcoded personal email from source to avoid leaking sensitive data and allow configurable default author identity via environment variable.

### Description
- Add a new `README.md` with project summary, problem statement, key features, tech stack, quick start, important scripts, and notes about environment variables and current limitations.
- Update `utils/constants.ts` to replace the hardcoded `MOCK_EMAIL` with `process.env.DEFAULT_AUTHOR_EMAIL ?? "demo@example.com"` so the default author email is configurable and non-personal.
- Documented that Sonnet validation is currently a placeholder and that API auth scaffolding is present but commented out in the codebase.

### Testing
- Ran TypeScript checks with `npm run lint:types` (`tsc --noEmit`) which passed.
- Pre-commit hooks executed linting tasks (Prettier + ESLint) successfully, but the `next build` step in the pre-commit/build hook failed due to inability to fetch the Google font `Roboto` in this environment, which is a network/environment issue rather than a code error.
- No runtime tests were added or modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2535b960c833085d792041ad5552a)